### PR TITLE
adds getGAID function

### DIFF
--- a/injection.js
+++ b/injection.js
@@ -1,5 +1,13 @@
-var GAID = "peter.k.hayes";
+var getGAID = function(){
+  var GAIDIndex = document.cookie.search('_ga=');
+  if( GAIDIndex > 0){ return document.cookie.substr(GAIDIndex+4, 26); }
+  else { return false; }
+};
+
+
+var GAID = getGAID() || "peter.k.hayes";
 var experiences = {};
+
 
 var hash = function(input){
   input = (typeof input === "string" ? input : input.toString());

--- a/injection.js
+++ b/injection.js
@@ -1,9 +1,8 @@
-var getGAID = function(){
-  var GAIDIndex = document.cookie.search('_ga=');
-  if( GAIDIndex > 0){ return document.cookie.substr(GAIDIndex+4, 26); }
-  else { return false; }
-};
-
+getGAID = function(){   
+  var key = '__utma';
+  var result;
+  return (result = new RegExp('(?:^|; )' + encodeURIComponent(key) + '=([^;]*)').exec(document.cookie)) ? (result[1]) : null;
+}
 
 var GAID = getGAID() || "peter.k.hayes";
 var experiences = {};


### PR DESCRIPTION
Chooses __utma  over _ga because __utma is automatically and always created when logging into a page with analytics. It tracks an individual user and expires after 2 years.
